### PR TITLE
Make internet connection check more robust & split file into multiple files

### DIFF
--- a/extensions/homeassistant/config.sh
+++ b/extensions/homeassistant/config.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+INTERVAL=60                             # (sec) - how often to update the script
+IMAGE_URI="http://example.org/test.png" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
+CLEAR_SCREEN_BEFORE_RENDER=0            # If "1", then the screen is completely cleared before rendering the newly fetched image to avoid "shadows".
+INTERVAL_ON_ERROR=30                    # In case of errors, the device waits this long until the next loop.
+BATTERYALERT=15                         # if the battery level is equal to or below this threshold, a info will be displayed
+BATTERYLOW=5                            # if the battery level is equal to or below this threshold, the "please charge" image will be shown and the device will sleep for a long time until it checks again (or boots up and starts the script again)
+BATTERYSLEEP=3600                       # 1 day sleep time when Battery Level is equal or below the "BATTERYLOW" threshold, see above.
+PINGHOST="www.google.com"               # which domain (or IP) to ping to check internet connectivity.
+ROUTERIP="192.168.0.1"                  # router gateway IP. The Kindle appears to sometimes forget the gateway's IP and we need to set this manually.
+LOGGING=1                               # if enabled, the script logs into a file
+DELAY_BEFORE_SUSPEND=10                 # seconds to wait between drawing image and suspending. This gives you time to SSH into your device if it's inside the photo frame and stop the daemon
+
+NAME=homeassistant
+NAMEOLD=homeassistant_old
+SCRIPTDIR="/mnt/us/extensions/homeassistant"
+LOGFILE="${SCRIPTDIR}/${NAME}.log"
+
+NET="wlan0"
+
+LIMG="${SCRIPTDIR}"
+LIMGBATT="${SCRIPTDIR}/low_battery.png"
+LIMGERR="${SCRIPTDIR}/error.png"
+LIMGERRWIFI="${SCRIPTDIR}/wifi.png"
+
+TMPFILE="${SCRIPTDIR}/cover.temp.png"
+SCREENSAVERFILE="${SCRIPTDIR}/cover.png"
+
+USE_RTC=1 # if 0, only sleep will be used (which is useful for debugging)
+RTC=1     # use rtc1 by default

--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -1,70 +1,27 @@
 #!/bin/sh
 
-INTERVAL=60 # (sec) - how often to update the script
-IMAGE_URI="http://example.org/test.png" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
-CLEAR_SCREEN_BEFORE_RENDER=0 # If "1", then the screen is completely cleared before rendering the newly fetched image to avoid "shadows".
-INTERVAL_ON_ERROR=30   # In case of errors, the device waits this long until the next loop.
-BATTERYALERT=15   # if the battery level is equal to or below this threshold, a info will be displayed
-BATTERYLOW=5      # if the battery level is equal to or below this threshold, the "please charge" image will be shown and the device will sleep for a long time until it checks again (or boots up and starts the script again)
-BATTERYSLEEP=3600 # 1 day sleep time when Battery Level is equal or below the "BATTERYLOW" threshold, see above.
-ROUTERIP="192.168.0.1" # router gateway IP. The Kindle appears to sometimes forget the gateway's IP and we need to set this manually.
-LOGGING=1 # if enabled, the script logs into a file
-DELAY_BEFORE_SUSPEND=10 # seconds to wait between drawing image and suspending. This gives you time to SSH into your device if it's inside the photo frame and stop the daemon
+# load config
+if [ -e "config.sh" ]; then
+    source ./config.sh
+else
+    logger "Could not find config.sh in $(pwd)"
+    echo "Could not find config.sh in $(pwd)"
+    exit
+fi
 
-NAME=homeassistant
-NAMEOLD=homeassistant_old
-SCRIPTDIR="/mnt/us/extensions/homeassistant"
-LOGFILE="${SCRIPTDIR}/${NAME}.log"
-
-NET="wlan0"
-RTC=1
-
-LIMG="${SCRIPTDIR}"
-LIMGBATT="${SCRIPTDIR}/low_battery.png"
-LIMGERR="${SCRIPTDIR}/error.png"
-LIMGERRWIFI="${SCRIPTDIR}/wifi.png"
-
-TMPFILE="${SCRIPTDIR}/cover.temp.png"
-SCREENSAVERFILE="${SCRIPTDIR}/cover.png"
-
-
-kill_kindle() {
-    /etc/init.d/framework stop >/dev/null 2>&1
-    /etc/init.d/cmd stop >/dev/null 2>&1
-    /etc/init.d/phd stop >/dev/null 2>&1
-    /etc/init.d/volumd stop >/dev/null 2>&1
-    /etc/init.d/tmd stop >/dev/null 2>&1
-    /etc/init.d/webreader stop >/dev/null 2>&1
-    killall lipc-wait-event >/dev/null 2>&1
-}
-
-customize_kindle() {
-    mkdir /mnt/us/update.bin.tmp.partial  -f # prevent from Amazon updates
-    touch /mnt/us/WIFI_NO_NET_PROBE # do not perform a WLAN test
-}
-
-wait_wlan() {
-    return $(lipc-get-prop com.lab126.wifid cmState | grep CONNECTED | wc -l)
-}
-
-logger() {
-    MSG=$1
-
-    # do nothing if logging is not enabled
-    if [ "x1" != "x$LOGGING" ]; then
-        return
-    fi
-
-    # if no logfile is specified, set a default
-    if [ -z $LOGFILE ]; then
-        $LOGFILE=stdout
-    fi
-
-    echo $(date): $MSG >>$LOGFILE
-}
+# load utils
+if [ -e "utils.sh" ]; then
+    source ./utils.sh
+else
+    logger "Could not find utils.sh in $(pwd)"
+    echo "Could not find utils.sh in $(pwd)"
+    exit
+fi
 
 kill_kindle
 customize_kindle
+
+GLOBAL_ERROR_COUNT=0
 
 while true; do
     echo "Starting new loop"
@@ -76,7 +33,7 @@ while true; do
     logger "Set prevent screen saver to true"
     lipc-set-prop com.lab126.powerd preventScreenSaver 1
 
-    echo "Check battery levle"
+    echo "Check battery level"
     CHECKBATTERY=$(gasgauge-info -s | sed 's/.$//')
     if [ ${CHECKBATTERY} -le ${BATTERYLOW} ]; then
         logger "Battery below ${BATTERYLOW}"
@@ -87,17 +44,23 @@ while true; do
         logger "Remaining battery ${CHECKBATTERY}"
     fi
 
-    ### activate WLAN
+    ### activate wifi
     logger "Enabling and checking wifi"
     lipc-set-prop com.lab126.wifid enable 1
 
     echo "Check wifi connection"
     WLANNOTCONNECTED=0
     WLANCOUNTER=0
+    PINGNOTWORKING=0
+    PINGCOUNTER=0
     ERROR_SUSPEND=0
 
-    ### wait for WLAN
+    ### wait for wifi
     while wait_wlan; do
+        if [ ${WLANCOUNTER} -gt 5]; then
+            logger "Trying Wifi reconnect"
+            /usr/bin/wpa_cli -i $NET reconnect
+        fi
         if [ ${WLANCOUNTER} -gt 30 ]; then
             logger "No known wifi found"
             logger "DEBUG ifconfig $(ifconfig ${NET})"
@@ -116,7 +79,7 @@ while true; do
     if [ ${WLANNOTCONNECTED} -eq 0 ]; then
         logger "Connected to wifi"
 
-        ### lost Standard Gateway if WLAN`s not available
+        ### lost standard gateway if wifi is not available
         GATEWAY=$(ip route | grep default | grep ${NET} | awk '{print $3}')
         logger "Found default gateway ${GATEWAY}"
         if [ -z "${GATEWAY}" ]; then
@@ -125,51 +88,97 @@ while true; do
             logger "Setting default gateway to ${ROUTERIP}"
         fi
 
-        ### download using cURL
+        echo "ping"
 
-        echo "Downloading and drawing image"
-        rm $TMPFILE -f
-        if wget -q "$IMAGE_URI" -O $TMPFILE; then
-            mv $TMPFILE $SCREENSAVERFILE
-            logger "Screen saver image file updated"
-            if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
-                eips -c
-                sleep 1
+        ### wait for working ping
+        while wait_ping; do
+            if [ ${PINGCOUNTER} -gt 5]; then
+                logger "Trying Wifi reconnect"
+                /usr/bin/wpa_cli -i $NET reconnect
             fi
-            eips -f -g ${SCREENSAVERFILE} #load picture to screen
-        else
-            logger "Error updating screensaver"
-            if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
-                eips -c
-                sleep 1
+            if [ ${PINGCOUNTER} -gt 10 ]; then
+                logger "Ping not working"
+                logger "DEBUG ifconfig $(ifconfig ${NET})"
+                CMSTATE=$(lipc-get-prop com.lab126.wifid cmState)
+                logger "DEBUG cmState ${CMSTATE}"
+                logger "DEBUG signalStrength $(lipc-get-prop com.lab126.wifid signalStrength)"
+                eips -f -g "${LIMGERRWIFI}"
+                PINGNOTWORKING=1
+                SHORTSUSPEND=1 #short sleeptime will be activated
+                break 1
             fi
-            eips -f -g ${LIMGERR}   #show error picture
-            ERROR_SUSPEND=1          #short sleep time will be activated
+            let PINGCOUNTER=PINGCOUNTER+1
+            logger "Waiting for working ping ${PINGCOUNTER}"
+            logger "Trying to set route gateway to ${ROUTERIP}"
+            route add default gw ${ROUTERIP}
+            sleep $PINGCOUNTER
+        done
+
+        if [ ${PINGNOTWORKING} -eq 0 ]; then
+            logger "Ping worked successfully"
+
+            echo "Downloading and drawing image"
+            DOWNLOADRESULT=$(wget -q "$IMAGE_URI" -O $TMPFILE)
+            logger "Download result ${DOWNLOADRESULT}"
+            echo $DOWNLOADRESULT
+            if $DOWNLOADRESULT; then
+                mv $TMPFILE $SCREENSAVERFILE
+                logger "Screen saver image file updated"
+                if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
+                    eips -c
+                    sleep 1
+                fi
+                eips -f -g ${SCREENSAVERFILE}
+            else
+                logger "Error updating screensaver"
+                if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
+                    eips -c
+                    sleep 1
+                fi
+                eips -f -g ${LIMGERR} #show error picture
+                ERROR_SUSPEND=1       #short sleep time will be activated
+            fi
+
+            rm ${TMPFILE} -f
+            logger "Removed temporary files"
+
+            if [ ${CHECKBATTERY} -le ${BATTERYALERT} ]; then
+                eips 2 2 -h " Battery at ${CHECKBATTERY}%, please charge "
+            fi
         fi
-
-        ### delete temp. files
-        rm ${TMPFILE} -f
-        logger "Removed temporary files"
-
-        if [ ${CHECKBATTERY} -le ${BATTERYALERT} ]; then
-            eips 2 2 -h " Akku bei 10 Prozent, bitte aufladen "
-        fi
-
     fi
-    
+
     sleep $DELAY_BEFORE_SUSPEND
 
     echo "Calculate next timer and going to sleep"
-    ### calculate and set WAKEUPTIMER
+
     if [ ${ERROR_SUSPEND} -eq 1 ]; then
+        let GLOBAL_ERROR_COUNT=GLOBAL_ERROR_COUNT+1
         TODAY=$(date +%s)
         WAKEUPTIME=$((${TODAY} + ${INTERVAL_ON_ERROR} - ${DELAY_BEFORE_SUSPEND}))
         logger "An error has occurred, will try again on ${WAKEUPTIME}"
-        ./rtcwake -d rtc$RTC -s $INTERVAL_ON_ERROR -m mem
+
+        if [ ${GLOBAL_ERROR_COUNT} -ge 10 ]; then
+            logger "REBOOT BECAUSE OF 10 ERRORS"
+            reboot
+        fi
+
+        if [ ${USE_RTC} -eq 1 ]; then
+            ./rtcwake -d rtc$RTC -s $INTERVAL_ON_ERROR -m mem
+        else
+            sleep $INTERVAL_ON_ERROR
+        fi
     else
+        GLOBAL_ERROR_COUNT=0
         TODAY=$(date +%s)
         WAKEUPTIME=$((${TODAY} + ${INTERVAL} - ${DELAY_BEFORE_SUSPEND}))
         logger "SUCCESS, will update again on ${WAKEUPTIME}"
-        ./rtcwake -d rtc$RTC -s $INTERVAL -m mem
+
+        if [ ${USE_RTC} -eq 1 ]; then
+            ./rtcwake -d rtc$RTC -s $INTERVAL -m mem
+        else
+            sleep $INTERVAL
+        fi
     fi
+
 done

--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+kill_kindle() {
+    /etc/init.d/framework stop >/dev/null 2>&1
+    /etc/init.d/cmd stop >/dev/null 2>&1
+    /etc/init.d/phd stop >/dev/null 2>&1
+    /etc/init.d/volumd stop >/dev/null 2>&1
+    /etc/init.d/tmd stop >/dev/null 2>&1
+    /etc/init.d/webreader stop >/dev/null 2>&1
+    killall lipc-wait-event >/dev/null 2>&1
+}
+
+customize_kindle() {
+    mkdir /mnt/us/update.bin.tmp.partial -f # prevent from Amazon updates
+    touch /mnt/us/WIFI_NO_NET_PROBE         # do not perform a WLAN test
+}
+
+wait_wlan() {
+    return $(lipc-get-prop com.lab126.wifid cmState | grep CONNECTED | wc -l)
+}
+
+wait_ping() {
+    CONNECTED=0
+    /bin/ping -c 1 $PINGHOST >/dev/null && CONNECTED=1
+    return $CONNECTED
+}
+
+logger() {
+    MSG=$1
+
+    # do nothing if logging is not enabled
+    if [ "x1" != "x$LOGGING" ]; then
+        return
+    fi
+
+    # if no logfile is specified, set a default
+    if [ -z $LOGFILE ]; then
+        $LOGFILE=stdout
+    fi
+
+    echo $(date): $MSG >>$LOGFILE
+}


### PR DESCRIPTION
This PR includes the following changes:

* split the `script.sh` into `config.sh` and `utils.sh` 
* add a `ping` check after validating the wifi connection
* run `/usr/bin/wpa_cli -i wlan0 reconnect` to reconnect to wifi after the wifi or ping check failed more than 5 times
* enforce adding the default gateway IP after the wifi connection succeeded but ping failed
* introduces a global error count, which causes the device to reboot if it failed to update the image 5 times in a row