### PR TITLE
Fix devices running out of battery even though they're constantly plugged in

### DIFF
--- a/extensions/homeassistant/config.sh
+++ b/extensions/homeassistant/config.sh
@@ -11,6 +11,7 @@ PINGHOST="www.google.com"               # which domain (or IP) to ping to check 
 ROUTERIP="192.168.0.1"                  # router gateway IP. The Kindle appears to sometimes forget the gateway's IP and we need to set this manually.
 LOGGING=1                               # if enabled, the script logs into a file
 DELAY_BEFORE_SUSPEND=10                 # seconds to wait between drawing image and suspending. This gives you time to SSH into your device if it's inside the photo frame and stop the daemon
+RESTART_POWERD_THRESHOLD=50 # restart powerd if battery percentage is below this value, if a power source is connected and the charging current is negative
 
 NAME=homeassistant
 NAMEOLD=homeassistant_old

--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -34,7 +34,19 @@ while true; do
     lipc-set-prop com.lab126.powerd preventScreenSaver 1
 
     echo "Check battery level"
+
+    CHARGING_FILE=`kdb get system/driver/charger/SYS_CHARGING_FILE`
+    IS_CHARGING=$(cat $CHARGING_FILE)
     CHECKBATTERY=$(gasgauge-info -s | sed 's/.$//')
+    CHECKCHARGECURRENT=$(gasgauge-info -l | sed 's/mA//g')
+    
+	logger "Battery: isCharging=${IS_CHARGING} percentage=${CHECKBATTERY}% current=${CHECKCHARGECURRENT}mA" 
+
+    if [ ${IS_CHARGING} -eq 1 ] && [ ${CHECKBATTERY} -le ${RESTART_POWERD_THRESHOLD} ] && [ ${CHECKCHARGECURRENT} -le 0 ]; then
+        logger "Restarting powerd"
+        /etc/init.d/powerd restart
+    fi
+    
     if [ ${CHECKBATTERY} -le ${BATTERYLOW} ]; then
         logger "Battery below ${BATTERYLOW}"
         eips -f -g "${LIMGBATT}"


### PR DESCRIPTION
It seems that Kindles charge up to 100% and then stop charging, which can be seen in a negative charging current.

Implementes workaround:
* powerd is restarted if the battery is low, the device's battery says its and gasgauge returns a negative charge count

This might fix #4 