### PR TITLE
Fix Kindle update session stop order

### DIFF
--- a/.agents/skills/kindle-initial-setup/SKILL.md
+++ b/.agents/skills/kindle-initial-setup/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: kindle-initial-setup
+description: Guide the first-time setup of this hass-lovelace-kindle-4 project on a Kindle 4 Non Touch. Use when installing the dashboard from scratch, preparing the Kindle jailbreak/USBNetwork/MKK/KUAL/kite prerequisites, configuring `extensions/homeassistant/config.sh`, copying the repo folders to `/mnt/us`, or validating the initial boot/startup workflow.
+---
+
+# Kindle Initial Setup
+
+## Overview
+
+Use this skill to guide a first installation of the Kindle-side Home Assistant dashboard scripts from this repository. Keep the workflow anchored to the files in this repo and the Kindle paths they expect.
+
+## Repo Facts
+
+- Copy local `extensions/homeassistant` to Kindle path `/mnt/us/extensions/homeassistant`.
+- Copy local `kite` to Kindle path `/mnt/us/kite`.
+- `kite/onboot/homeassistant.sh` backgrounds `/mnt/us/extensions/homeassistant/startup.sh`.
+- `startup.sh` waits 120 seconds, then starts `/mnt/us/extensions/homeassistant/daemon.sh start`.
+- `daemon.sh` runs `script.sh` and writes `/mnt/us/extensions/homeassistant/homeassistant.pid`.
+- `script.sh` fetches `IMAGE_URI`, renders it with `eips`, then suspends with `rtcwake` unless `USE_RTC=0`.
+
+## Initial Setup Workflow
+
+1. Confirm prerequisites with the user:
+   - Kindle 4 Non Touch is jailbroken.
+   - USBNetwork is installed and SSH works.
+   - Mobileread Kindle Kit is installed so KUAL can run.
+   - KUAL v1 AZW is copied to `/mnt/us/documents`.
+   - kite is installed so boot scripts in `/mnt/us/kite/onboot` run.
+
+2. Configure the repository before copying:
+   - Edit `extensions/homeassistant/config.sh`.
+   - Set `IMAGE_URI` to the plain HTTP rendered-image endpoint.
+   - Adjust `INTERVAL`, `INTERVAL_ON_ERROR`, `DELAY_BEFORE_SUSPEND`, battery thresholds, `PINGHOST`, and `ROUTERIP` for the local network.
+   - Keep LF line endings on all `*.sh` files.
+
+3. Validate local shell files before transfer:
+
+```sh
+sh -n extensions/homeassistant/config.sh
+sh -n extensions/homeassistant/utils.sh
+sh -n extensions/homeassistant/script.sh
+sh -n extensions/homeassistant/startup.sh
+sh -n kite/onboot/homeassistant.sh
+bash -n extensions/homeassistant/daemon.sh
+```
+
+4. Copy files to the Kindle. Prefer `scp` or `rsync` using the actual SSH target configured for the device. USBNetwork commonly exposes the Kindle at `root@192.168.15.244`, but do not assume that if the user has a Wi-Fi IP or custom SSH config.
+
+```sh
+scp -r extensions/homeassistant root@KINDLE_HOST:/mnt/us/extensions/
+scp -r kite root@KINDLE_HOST:/mnt/us/
+```
+
+5. Reboot the Kindle and watch the startup window:
+   - `startup.sh` intentionally waits 120 seconds before starting the daemon.
+   - Use this window to SSH in if immediate troubleshooting is needed.
+   - After the delay, `daemon.sh start` begins the render/sleep loop.
+
+6. Confirm first run:
+   - Check `/mnt/us/extensions/homeassistant/homeassistant.log` when `LOGGING=1`.
+   - Confirm `daemon.sh status` reports the service running after the startup delay.
+   - Confirm the screen eventually renders the fetched image or one of the error images.
+
+## Troubleshooting Checks
+
+- If SSH disconnects after the dashboard starts, the script likely suspended the Kindle. Reboot and use the 120 second startup window, or connect during `DELAY_BEFORE_SUSPEND` after a render.
+- If Wi-Fi works but routing is lost after sleep, verify `ROUTERIP` in `config.sh`; `script.sh` adds it as the default gateway when none is found.
+- If the image never downloads, verify that `IMAGE_URI` is HTTP, not HTTPS, and that the Kindle can ping `PINGHOST`.
+- If updates or debugging are needed on an already installed Kindle, switch to the `kindle-update-session` skill.

--- a/.agents/skills/kindle-initial-setup/agents/openai.yaml
+++ b/.agents/skills/kindle-initial-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kindle Initial Setup"
+  short_description: "Set up a Kindle 4 Home Assistant dashboard from this repo."
+  default_prompt: "Guide the initial setup of this Kindle Home Assistant dashboard."

--- a/.agents/skills/kindle-update-session/SKILL.md
+++ b/.agents/skills/kindle-update-session/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: kindle-update-session
+description: Guide a maintenance session for a Kindle that already has this hass-lovelace-kindle-4 project installed. Use when rebooting the Kindle, connecting by SSH during the configured startup or post-render window, stopping the queued startup/daemon so SSH remains connected, inspecting logs, updating files under `/mnt/us/extensions/homeassistant` or `/mnt/us/kite`, and restarting or validating the service after changes.
+---
+
+# Kindle Update Session
+
+## Overview
+
+Use this skill to keep an SSH session alive long enough to inspect, debug, or update an already installed Kindle dashboard. The key is to stop both the running daemon and any pending startup script before the render loop can suspend the device.
+
+## Repo-Derived Timing
+
+- Boot path: `kite/onboot/homeassistant.sh` runs `startup.sh` in the background.
+- Startup window: `startup.sh` sleeps 120 seconds before `daemon.sh start`.
+- Running loop: `script.sh` renders the image, waits `DELAY_BEFORE_SUSPEND`, then suspends with `rtcwake` when `USE_RTC=1`.
+- Stop command: `sh /mnt/us/extensions/homeassistant/daemon.sh stop` sends HUP to the PID recorded in `/mnt/us/extensions/homeassistant/homeassistant.pid`.
+
+## Maintenance Workflow
+
+1. Prepare local changes before touching the Kindle:
+   - Run the repo validation from `AGENTS.md`.
+   - Keep the list of changed files small and know which paths must be copied.
+   - Use the actual Kindle SSH target. USBNetwork commonly uses `root@192.168.15.244`; Wi-Fi installs may use a router-assigned IP or SSH alias.
+
+2. Reboot or wake the Kindle, then connect during a known window:
+
+```sh
+ssh root@KINDLE_HOST
+```
+
+3. Immediately cancel any pending boot startup before it can launch the render loop:
+
+```sh
+ps | grep '[s]tartup.sh'
+PID=$(ps | grep '[s]tartup.sh' | awk '{print $1}')
+[ -n "$PID" ] && kill -HUP $PID
+```
+
+4. Stop the daemon if it is already running:
+
+```sh
+ps | grep '[s]cript.sh'
+sh /mnt/us/extensions/homeassistant/daemon.sh stop
+```
+
+5. Confirm the device should stay reachable:
+
+```sh
+ps | grep '[s]tartup.sh'
+ps | grep '[s]cript.sh'
+sh /mnt/us/extensions/homeassistant/daemon.sh status
+```
+
+Expected result: no `startup.sh` process, no `script.sh` render loop, and the daemon status is stopped or reports a stale pidfile rather than a running process.
+
+6. Inspect logs and state as needed:
+
+```sh
+tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
+cat /mnt/us/extensions/homeassistant/config.sh
+ls -la /mnt/us/extensions/homeassistant
+```
+
+7. Copy updates from the local machine. Prefer `rsync` when available locally; fall back to `scp` if needed:
+
+```sh
+rsync -av extensions/homeassistant/ root@KINDLE_HOST:/mnt/us/extensions/homeassistant/
+rsync -av kite/ root@KINDLE_HOST:/mnt/us/kite/
+```
+
+8. Restart and validate on the Kindle:
+
+```sh
+sh /mnt/us/extensions/homeassistant/daemon.sh start
+sh /mnt/us/extensions/homeassistant/daemon.sh status
+tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
+```
+
+## Choosing The Connection Window
+
+- Prefer the boot window when doing planned updates. Reboot, connect within 120 seconds, stop `startup.sh` first, then stop the daemon.
+- Use the post-render window only for quick emergency stops. It lasts `DELAY_BEFORE_SUSPEND` seconds after drawing, which defaults to 10 seconds in `config.sh`.
+- If the Kindle suspends before commands complete, reboot and use the boot window; do not rely on repeated post-render attempts for multi-file updates.
+
+## Validation Boundary
+
+These steps are validated against the repository scripts, but a live Kindle session still depends on the device's USBNetwork or Wi-Fi SSH configuration. When using this skill, explicitly confirm the actual `KINDLE_HOST`, whether the connection is USBNetwork or Wi-Fi, and whether `startup.sh` or `script.sh` is currently running before copying updates.

--- a/.agents/skills/kindle-update-session/agents/openai.yaml
+++ b/.agents/skills/kindle-update-session/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kindle Update Session"
+  short_description: "Connect to an installed Kindle for updates."
+  default_prompt: "Guide a maintenance SSH session for an already installed Kindle dashboard."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidance
+
+## Project Shape
+
+- This repository contains the Kindle-side scripts for a Kindle 4 Non Touch Home Assistant Lovelace dashboard.
+- The deployed Kindle paths are fixed: `extensions/homeassistant` is copied to `/mnt/us/extensions/homeassistant`, and `kite/onboot/homeassistant.sh` is copied to `/mnt/us/kite/onboot/homeassistant.sh`.
+- The runtime is an old Kindle/Linux environment with BusyBox-era userland. Keep shell changes conservative and avoid assuming GNU-only options.
+
+## Working On Scripts
+
+- Treat `extensions/homeassistant/config.sh` as user-editable configuration.
+- Keep `extensions/homeassistant/script.sh`, `utils.sh`, and `startup.sh` compatible with the Kindle shell environment; prefer simple POSIX-style shell unless an existing script already uses Bash.
+- `extensions/homeassistant/daemon.sh` is Bash and controls the long-running `script.sh` process through `/mnt/us/extensions/homeassistant/homeassistant.pid`.
+- Do not modify binary/image assets such as `extensions/homeassistant/rtcwake`, `*.png`, or `assets/*.jpg` unless the task explicitly requires it.
+- Preserve LF line endings for all shell scripts.
+
+## Validation
+
+- Run shell syntax checks after script edits:
+
+```sh
+sh -n extensions/homeassistant/config.sh
+sh -n extensions/homeassistant/utils.sh
+sh -n extensions/homeassistant/script.sh
+sh -n extensions/homeassistant/startup.sh
+sh -n kite/onboot/homeassistant.sh
+bash -n extensions/homeassistant/daemon.sh
+```
+
+- When changing download behavior, account for the Kindle 4 limitation documented in `README.md`: the image URL must be plain HTTP because SSL/TLS is not supported by the device workflow.
+- When changing sleep, startup, or update behavior, validate against these repository facts:
+  - `kite/onboot/homeassistant.sh` starts `startup.sh` in the background.
+  - `startup.sh` waits 120 seconds, then runs `daemon.sh start`.
+  - `script.sh` waits `DELAY_BEFORE_SUSPEND` seconds after rendering before suspending.
+
+## Local Skills
+
+- Use `.agents/skills/kindle-initial-setup` when guiding a first-time installation of this project on a Kindle.
+- Use `.agents/skills/kindle-update-session` when connecting to an already installed Kindle for debugging or file updates.


### PR DESCRIPTION
## Summary
- add repository agent guidance and local Kindle workflow skills
- order the update-session workflow to stop pending startup before daemon stop
- document the validated startup timing that makes this order necessary

## Tests
- PYTHONPATH=/tmp/codex-pyyaml python3 /Users/sibbl/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/kindle-initial-setup
- PYTHONPATH=/tmp/codex-pyyaml python3 /Users/sibbl/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/kindle-update-session
- git diff --check -- .agents AGENTS.md