### PR TITLE
Fix logger fallback output

### DIFF
--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -33,10 +33,10 @@ logger() {
         return
     fi
 
-    # if no logfile is specified, set a default
-    if [ -z $LOGFILE ]; then
-        $LOGFILE=stdout
+    if [ -z "$LOGFILE" ]; then
+        echo "$(date): $MSG"
+        return
     fi
 
-    echo $(date): $MSG >>$LOGFILE
+    echo "$(date): $MSG" >>"$LOGFILE"
 }


### PR DESCRIPTION
## Summary
- quote LOGFILE when checking and writing logs
- write logger output to stdout when LOGFILE is unset instead of trying to execute an invalid assignment

## Tests
- sh -n extensions/homeassistant/utils.sh
- sh -c '. extensions/homeassistant/utils.sh; LOGGING=1; LOGFILE=; logger test-message'
- git diff --check -- extensions/homeassistant/utils.sh