### PR TITLE
Fix daemon stop pidfile check

### DIFF
--- a/extensions/homeassistant/daemon.sh
+++ b/extensions/homeassistant/daemon.sh
@@ -38,9 +38,9 @@ status)
 ;;
 stop)
         printf "%-50s" "Stopping $NAME"
-            PID=`cat $PIDFILE`
             cd $DAEMON_PATH
         if [ -f $PIDFILE ]; then
+            PID=`cat $PIDFILE`
             kill -HUP $PID
             printf "%s\n" "Ok"
             rm -f $PIDFILE


### PR DESCRIPTION
## Summary
- check that the daemon pidfile exists before reading it in the stop command
- avoid a noisy cat error when stopping before the daemon has started

## Tests
- bash -n extensions/homeassistant/daemon.sh
- git diff --check -- extensions/homeassistant/daemon.sh