### PR TITLE
Bundle Kindle deploy fixes

### DIFF
--- a/.agents/skills/kindle-update-session/SKILL.md
+++ b/.agents/skills/kindle-update-session/SKILL.md
@@ -24,7 +24,7 @@ Use this skill to keep an SSH session alive long enough to inspect, debug, or up
 .agents/skills/kindle-update-session/scripts/kindle-update-session.sh deploy
 ```
 
-The script defaults to `KINDLE_HOST=192.168.0.172` and `KINDLE_USER=root`. It waits for SSH, cancels a pending `startup.sh`, stops the daemon if present, copies `extensions/homeassistant` and `kite`, restarts the daemon, and prints status/log output.
+The script defaults to `KINDLE_HOST=192.168.0.172` and `KINDLE_USER=root`. It waits for SSH, cancels a pending `startup.sh`, stops the daemon and any leftover `script.sh` processes if present, copies `extensions/homeassistant` and `kite`, restarts the daemon, and prints process/service status.
 
 The script expects non-interactive SSH by default. If it reports `Permission denied (publickey,password)`, configure an SSH key for `root@KINDLE_HOST` first, or run with `KINDLE_SSH_BATCH_MODE=no` for an interactive password prompt:
 
@@ -64,6 +64,8 @@ PID=$(ps | grep '[s]tartup.sh' | awk '{print $1}')
 ```sh
 ps | grep '[s]cript.sh'
 sh /mnt/us/extensions/homeassistant/daemon.sh stop
+PIDS=$(ps | grep '[s]cript.sh' | awk '{print $1}')
+[ -n "$PIDS" ] && kill -HUP $PIDS
 ```
 
 6. Confirm the device should stay reachable:
@@ -79,7 +81,7 @@ Expected result: no `startup.sh` process, no `script.sh` render loop, and the da
 7. Inspect logs and state as needed:
 
 ```sh
-tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
+[ -f /mnt/us/extensions/homeassistant/homeassistant.log ] && tail -100 /mnt/us/extensions/homeassistant/homeassistant.log
 cat /mnt/us/extensions/homeassistant/config.sh
 ls -la /mnt/us/extensions/homeassistant
 ```
@@ -87,8 +89,8 @@ ls -la /mnt/us/extensions/homeassistant
 8. Copy updates from the local machine. Prefer `rsync` when available locally; fall back to `scp` if needed:
 
 ```sh
-rsync -av extensions/homeassistant/ root@KINDLE_HOST:/mnt/us/extensions/homeassistant/
-rsync -av kite/ root@KINDLE_HOST:/mnt/us/kite/
+rsync -rltv --no-owner --no-group --no-perms extensions/homeassistant/ root@KINDLE_HOST:/mnt/us/extensions/homeassistant/
+rsync -rltv --no-owner --no-group --no-perms kite/ root@KINDLE_HOST:/mnt/us/kite/
 ```
 
 9. Restart and validate on the Kindle:
@@ -96,7 +98,7 @@ rsync -av kite/ root@KINDLE_HOST:/mnt/us/kite/
 ```sh
 sh /mnt/us/extensions/homeassistant/daemon.sh start
 sh /mnt/us/extensions/homeassistant/daemon.sh status
-tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
+[ -f /mnt/us/extensions/homeassistant/homeassistant.log ] && tail -100 /mnt/us/extensions/homeassistant/homeassistant.log
 ```
 
 ## Choosing The Connection Window

--- a/.agents/skills/kindle-update-session/SKILL.md
+++ b/.agents/skills/kindle-update-session/SKILL.md
@@ -18,18 +18,40 @@ Use this skill to keep an SSH session alive long enough to inspect, debug, or up
 
 ## Maintenance Workflow
 
-1. Prepare local changes before touching the Kindle:
+1. Prefer the bundled shell script for update sessions:
+
+```sh
+.agents/skills/kindle-update-session/scripts/kindle-update-session.sh deploy
+```
+
+The script defaults to `KINDLE_HOST=192.168.0.172` and `KINDLE_USER=root`. It waits for SSH, cancels a pending `startup.sh`, stops the daemon if present, copies `extensions/homeassistant` and `kite`, restarts the daemon, and prints status/log output.
+
+The script expects non-interactive SSH by default. If it reports `Permission denied (publickey,password)`, configure an SSH key for `root@KINDLE_HOST` first, or run with `KINDLE_SSH_BATCH_MODE=no` for an interactive password prompt:
+
+```sh
+KINDLE_SSH_BATCH_MODE=no .agents/skills/kindle-update-session/scripts/kindle-update-session.sh deploy
+```
+
+Use these variants when needed:
+
+```sh
+KINDLE_HOST=192.168.0.172 .agents/skills/kindle-update-session/scripts/kindle-update-session.sh wait
+KINDLE_HOST=192.168.0.172 .agents/skills/kindle-update-session/scripts/kindle-update-session.sh stop
+KINDLE_HOST=192.168.0.172 .agents/skills/kindle-update-session/scripts/kindle-update-session.sh status
+```
+
+2. Prepare local changes before touching the Kindle:
    - Run the repo validation from `AGENTS.md`.
    - Keep the list of changed files small and know which paths must be copied.
    - Use the actual Kindle SSH target. USBNetwork commonly uses `root@192.168.15.244`; Wi-Fi installs may use a router-assigned IP or SSH alias.
 
-2. Reboot or wake the Kindle, then connect during a known window:
+3. Reboot or wake the Kindle, then connect during a known window:
 
 ```sh
 ssh root@KINDLE_HOST
 ```
 
-3. Immediately cancel any pending boot startup before it can launch the render loop:
+4. Immediately cancel any pending boot startup before it can launch the render loop:
 
 ```sh
 ps | grep '[s]tartup.sh'
@@ -37,14 +59,14 @@ PID=$(ps | grep '[s]tartup.sh' | awk '{print $1}')
 [ -n "$PID" ] && kill -HUP $PID
 ```
 
-4. Stop the daemon if it is already running:
+5. Stop the daemon if it is already running:
 
 ```sh
 ps | grep '[s]cript.sh'
 sh /mnt/us/extensions/homeassistant/daemon.sh stop
 ```
 
-5. Confirm the device should stay reachable:
+6. Confirm the device should stay reachable:
 
 ```sh
 ps | grep '[s]tartup.sh'
@@ -54,7 +76,7 @@ sh /mnt/us/extensions/homeassistant/daemon.sh status
 
 Expected result: no `startup.sh` process, no `script.sh` render loop, and the daemon status is stopped or reports a stale pidfile rather than a running process.
 
-6. Inspect logs and state as needed:
+7. Inspect logs and state as needed:
 
 ```sh
 tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
@@ -62,14 +84,14 @@ cat /mnt/us/extensions/homeassistant/config.sh
 ls -la /mnt/us/extensions/homeassistant
 ```
 
-7. Copy updates from the local machine. Prefer `rsync` when available locally; fall back to `scp` if needed:
+8. Copy updates from the local machine. Prefer `rsync` when available locally; fall back to `scp` if needed:
 
 ```sh
 rsync -av extensions/homeassistant/ root@KINDLE_HOST:/mnt/us/extensions/homeassistant/
 rsync -av kite/ root@KINDLE_HOST:/mnt/us/kite/
 ```
 
-8. Restart and validate on the Kindle:
+9. Restart and validate on the Kindle:
 
 ```sh
 sh /mnt/us/extensions/homeassistant/daemon.sh start
@@ -86,3 +108,5 @@ tail -n 100 /mnt/us/extensions/homeassistant/homeassistant.log
 ## Validation Boundary
 
 These steps are validated against the repository scripts, but a live Kindle session still depends on the device's USBNetwork or Wi-Fi SSH configuration. When using this skill, explicitly confirm the actual `KINDLE_HOST`, whether the connection is USBNetwork or Wi-Fi, and whether `startup.sh` or `script.sh` is currently running before copying updates.
+
+The bundled script is intentionally polling SSH rather than ping. The Kindle may answer only briefly between render/suspend cycles, and SSH availability is the condition that matters for stopping the service.

--- a/.agents/skills/kindle-update-session/SKILL.md
+++ b/.agents/skills/kindle-update-session/SKILL.md
@@ -26,6 +26,22 @@ Use this skill to keep an SSH session alive long enough to inspect, debug, or up
 
 The script defaults to `KINDLE_HOST=192.168.0.172` and `KINDLE_USER=root`. It waits for SSH, cancels a pending `startup.sh`, stops the daemon and any leftover `script.sh` processes if present, copies `extensions/homeassistant` and `kite`, restarts the daemon, and prints process/service status.
 
+By default it does not overwrite `/mnt/us/extensions/homeassistant/config.sh`, because that file contains device-specific settings.
+
+Never overwrite the Kindle's `config.sh` blindly. Before any config deploy, read the current remote file and preserve a backup. The bundled script enforces this: `DEPLOY_CONFIG=yes` first reads the Kindle config, writes a local backup under `.git/kindle-update-session-backups/`, writes a remote backup next to the original config, and prints the current remote config. It then refuses to overwrite unless `CONFIRM_DEPLOY_CONFIG=yes` is also set.
+
+Use `DEPLOY_CONFIG=yes` without confirmation only to inspect and back up the current Kindle config:
+
+```sh
+DEPLOY_CONFIG=yes .agents/skills/kindle-update-session/scripts/kindle-update-session.sh deploy
+```
+
+Use both flags only after reviewing the printed remote config and intentionally deciding to replace it:
+
+```sh
+DEPLOY_CONFIG=yes CONFIRM_DEPLOY_CONFIG=yes .agents/skills/kindle-update-session/scripts/kindle-update-session.sh deploy
+```
+
 The script expects non-interactive SSH by default. If it reports `Permission denied (publickey,password)`, configure an SSH key for `root@KINDLE_HOST` first, or run with `KINDLE_SSH_BATCH_MODE=no` for an interactive password prompt:
 
 ```sh

--- a/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
+++ b/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+set -u
+
+KINDLE_HOST=${KINDLE_HOST:-192.168.0.172}
+KINDLE_USER=${KINDLE_USER:-root}
+KINDLE_TARGET="${KINDLE_USER}@${KINDLE_HOST}"
+WAIT_TIMEOUT=${WAIT_TIMEOUT:-180}
+SLEEP_SECONDS=${SLEEP_SECONDS:-2}
+REPO_ROOT=${REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)}
+ACTION=${1:-deploy}
+KINDLE_SSH_BATCH_MODE=${KINDLE_SSH_BATCH_MODE:-yes}
+KINDLE_SSH_EXTRA_OPTS=${KINDLE_SSH_EXTRA_OPTS:-}
+
+SSH_OPTS="-o BatchMode=${KINDLE_SSH_BATCH_MODE} -o ConnectTimeout=3 -o ConnectionAttempts=1 -o StrictHostKeyChecking=accept-new ${KINDLE_SSH_EXTRA_OPTS}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [wait|stop|deploy|start|status]
+
+Environment:
+  KINDLE_HOST     Kindle IP or hostname (default: 192.168.0.172)
+  KINDLE_USER     SSH user (default: root)
+  WAIT_TIMEOUT    Seconds to wait for SSH (default: 180)
+  SLEEP_SECONDS   Poll interval in seconds (default: 2)
+  REPO_ROOT       Repository root (auto-detected by default)
+  KINDLE_SSH_BATCH_MODE
+                  Use "no" to allow interactive password prompts (default: yes)
+  KINDLE_SSH_EXTRA_OPTS
+                  Extra options passed to ssh/scp/rsync ssh
+
+Actions:
+  wait     Wait until SSH is available.
+  stop     Wait for SSH, cancel startup.sh, stop daemon.sh, and print status.
+  deploy   Stop, copy this repo's Kindle files, start the daemon, and print status.
+  start    Wait for SSH, start daemon.sh, and print status.
+  status   Wait for SSH and print process/service/log status.
+EOF
+}
+
+log() {
+    printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+run_ssh() {
+    ssh $SSH_OPTS "$KINDLE_TARGET" "$@"
+}
+
+wait_for_ssh() {
+    START=$(date +%s)
+    SSH_ERROR_FILE="/tmp/kindle-update-session-ssh.$$"
+    rm -f "$SSH_ERROR_FILE"
+
+    log "Waiting up to ${WAIT_TIMEOUT}s for SSH on ${KINDLE_TARGET}"
+    while :; do
+        if run_ssh 'true' >/dev/null 2>"$SSH_ERROR_FILE"; then
+            rm -f "$SSH_ERROR_FILE"
+            log "SSH is available on ${KINDLE_TARGET}"
+            return 0
+        fi
+
+        if grep -qi 'Permission denied' "$SSH_ERROR_FILE" 2>/dev/null; then
+            log "SSH reached ${KINDLE_TARGET}, but authentication failed"
+            log "Install/configure an SSH key for ${KINDLE_TARGET}, or rerun with KINDLE_SSH_BATCH_MODE=no for an interactive password prompt"
+            cat "$SSH_ERROR_FILE" >&2
+            rm -f "$SSH_ERROR_FILE"
+            return 2
+        fi
+
+        NOW=$(date +%s)
+        ELAPSED=$((NOW - START))
+        if [ "$ELAPSED" -ge "$WAIT_TIMEOUT" ]; then
+            log "Timed out waiting for SSH on ${KINDLE_TARGET}"
+            if [ -s "$SSH_ERROR_FILE" ]; then
+                log "Last SSH error:"
+                cat "$SSH_ERROR_FILE" >&2
+            fi
+            rm -f "$SSH_ERROR_FILE"
+            return 1
+        fi
+
+        sleep "$SLEEP_SECONDS"
+    done
+}
+
+remote_status() {
+    run_ssh '
+        echo "== processes =="
+        ps | grep "[s]tartup.sh" || true
+        ps | grep "[s]cript.sh" || true
+        echo "== daemon =="
+        sh /mnt/us/extensions/homeassistant/daemon.sh status || true
+        echo "== recent log =="
+        tail -n 20 /mnt/us/extensions/homeassistant/homeassistant.log 2>/dev/null || true
+    '
+}
+
+remote_stop() {
+    run_ssh '
+        echo "Canceling pending startup.sh if present"
+        PID=$(ps | grep "[s]tartup.sh" | awk "{print \$1}")
+        [ -n "$PID" ] && kill -HUP $PID || true
+
+        echo "Stopping homeassistant daemon if present"
+        sh /mnt/us/extensions/homeassistant/daemon.sh stop || true
+
+        echo "Remaining dashboard processes"
+        ps | grep "[s]tartup.sh" || true
+        ps | grep "[s]cript.sh" || true
+    '
+}
+
+copy_updates() {
+    if command -v rsync >/dev/null 2>&1; then
+        log "Copying extensions/homeassistant with rsync"
+        rsync -av -e "ssh $SSH_OPTS" \
+            "$REPO_ROOT/extensions/homeassistant/" \
+            "$KINDLE_TARGET:/mnt/us/extensions/homeassistant/"
+
+        log "Copying kite with rsync"
+        rsync -av -e "ssh $SSH_OPTS" \
+            "$REPO_ROOT/kite/" \
+            "$KINDLE_TARGET:/mnt/us/kite/"
+    else
+        log "rsync not found; copying with scp"
+        scp $SSH_OPTS -r "$REPO_ROOT/extensions/homeassistant" "$KINDLE_TARGET:/mnt/us/extensions/"
+        scp $SSH_OPTS -r "$REPO_ROOT/kite" "$KINDLE_TARGET:/mnt/us/"
+    fi
+}
+
+remote_start() {
+    run_ssh '
+        echo "Starting homeassistant daemon"
+        sh /mnt/us/extensions/homeassistant/daemon.sh start
+        sh /mnt/us/extensions/homeassistant/daemon.sh status || true
+    '
+}
+
+case "$ACTION" in
+wait)
+    wait_for_ssh
+    ;;
+stop)
+    wait_for_ssh && remote_stop && remote_status
+    ;;
+deploy)
+    wait_for_ssh && remote_stop && copy_updates && remote_start && remote_status
+    ;;
+start)
+    wait_for_ssh && remote_start && remote_status
+    ;;
+status)
+    wait_for_ssh && remote_status
+    ;;
+-h|--help|help)
+    usage
+    ;;
+*)
+    usage
+    exit 2
+    ;;
+esac

--- a/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
+++ b/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
@@ -90,8 +90,8 @@ remote_status() {
         ps | grep "[s]cript.sh" || true
         echo "== daemon =="
         sh /mnt/us/extensions/homeassistant/daemon.sh status || true
-        echo "== recent log =="
-        tail -n 20 /mnt/us/extensions/homeassistant/homeassistant.log 2>/dev/null || true
+        echo "== log file =="
+        ls -l /mnt/us/extensions/homeassistant/homeassistant.log 2>/dev/null || true
     '
 }
 
@@ -104,6 +104,13 @@ remote_stop() {
         echo "Stopping homeassistant daemon if present"
         sh /mnt/us/extensions/homeassistant/daemon.sh stop || true
 
+        echo "Stopping leftover script.sh processes if present"
+        PIDS=$(ps | grep "[s]cript.sh" | awk "{print \$1}")
+        [ -n "$PIDS" ] && kill $PIDS || true
+        sleep 1
+        PIDS=$(ps | grep "[s]cript.sh" | awk "{print \$1}")
+        [ -n "$PIDS" ] && kill -9 $PIDS || true
+
         echo "Remaining dashboard processes"
         ps | grep "[s]tartup.sh" || true
         ps | grep "[s]cript.sh" || true
@@ -113,12 +120,12 @@ remote_stop() {
 copy_updates() {
     if command -v rsync >/dev/null 2>&1; then
         log "Copying extensions/homeassistant with rsync"
-        rsync -av -e "ssh $SSH_OPTS" \
+        rsync -rltv --no-owner --no-group --no-perms -e "ssh $SSH_OPTS" \
             "$REPO_ROOT/extensions/homeassistant/" \
             "$KINDLE_TARGET:/mnt/us/extensions/homeassistant/"
 
         log "Copying kite with rsync"
-        rsync -av -e "ssh $SSH_OPTS" \
+        rsync -rltv --no-owner --no-group --no-perms -e "ssh $SSH_OPTS" \
             "$REPO_ROOT/kite/" \
             "$KINDLE_TARGET:/mnt/us/kite/"
     else
@@ -131,7 +138,7 @@ copy_updates() {
 remote_start() {
     run_ssh '
         echo "Starting homeassistant daemon"
-        sh /mnt/us/extensions/homeassistant/daemon.sh start
+        sh /mnt/us/extensions/homeassistant/daemon.sh start </dev/null
         sh /mnt/us/extensions/homeassistant/daemon.sh status || true
     '
 }

--- a/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
+++ b/.agents/skills/kindle-update-session/scripts/kindle-update-session.sh
@@ -11,6 +11,9 @@ REPO_ROOT=${REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)}
 ACTION=${1:-deploy}
 KINDLE_SSH_BATCH_MODE=${KINDLE_SSH_BATCH_MODE:-yes}
 KINDLE_SSH_EXTRA_OPTS=${KINDLE_SSH_EXTRA_OPTS:-}
+DEPLOY_CONFIG=${DEPLOY_CONFIG:-no}
+CONFIRM_DEPLOY_CONFIG=${CONFIRM_DEPLOY_CONFIG:-no}
+CONFIG_BACKUP_DIR=${CONFIG_BACKUP_DIR:-"$REPO_ROOT/.git/kindle-update-session-backups"}
 
 SSH_OPTS="-o BatchMode=${KINDLE_SSH_BATCH_MODE} -o ConnectTimeout=3 -o ConnectionAttempts=1 -o StrictHostKeyChecking=accept-new ${KINDLE_SSH_EXTRA_OPTS}"
 
@@ -28,6 +31,13 @@ Environment:
                   Use "no" to allow interactive password prompts (default: yes)
   KINDLE_SSH_EXTRA_OPTS
                   Extra options passed to ssh/scp/rsync ssh
+  DEPLOY_CONFIG   Set to "yes" to overwrite config.sh on the Kindle (default: no)
+  CONFIRM_DEPLOY_CONFIG
+                  Must also be "yes" when DEPLOY_CONFIG=yes. The script first
+                  reads and backs up the remote config, then overwrites it.
+  CONFIG_BACKUP_DIR
+                  Local directory for remote config backups
+                  (default: .git/kindle-update-session-backups)
 
 Actions:
   wait     Wait until SSH is available.
@@ -117,10 +127,57 @@ remote_stop() {
     '
 }
 
+backup_remote_config() {
+    TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
+    LOCAL_BACKUP="${CONFIG_BACKUP_DIR}/config.${KINDLE_HOST}.${TIMESTAMP}.sh"
+    REMOTE_BACKUP="/mnt/us/extensions/homeassistant/config.sh.backup.${TIMESTAMP}"
+
+    mkdir -p "$CONFIG_BACKUP_DIR"
+
+    log "Reading current remote config before any config deploy"
+    if ! run_ssh 'test -f /mnt/us/extensions/homeassistant/config.sh'; then
+        log "Remote config.sh does not exist; refusing to deploy config automatically"
+        return 1
+    fi
+
+    if ! ssh $SSH_OPTS "$KINDLE_TARGET" 'cat /mnt/us/extensions/homeassistant/config.sh' >"$LOCAL_BACKUP"; then
+        log "Could not read remote config.sh; refusing to deploy config"
+        return 1
+    fi
+
+    run_ssh "cp /mnt/us/extensions/homeassistant/config.sh '$REMOTE_BACKUP'"
+    log "Saved local remote-config backup to $LOCAL_BACKUP"
+    log "Saved Kindle remote-config backup to $REMOTE_BACKUP"
+    log "Current remote config follows:"
+    sed -n '1,80p' "$LOCAL_BACKUP"
+}
+
+guard_config_deploy() {
+    if [ "$DEPLOY_CONFIG" != "yes" ]; then
+        return 0
+    fi
+
+    backup_remote_config || return 1
+
+    if [ "$CONFIRM_DEPLOY_CONFIG" != "yes" ]; then
+        log "Refusing to overwrite config.sh without CONFIRM_DEPLOY_CONFIG=yes"
+        log "Review the backup above, then rerun with DEPLOY_CONFIG=yes CONFIRM_DEPLOY_CONFIG=yes if overwrite is intended"
+        return 1
+    fi
+
+    log "Config overwrite explicitly confirmed"
+}
+
 copy_updates() {
+    RSYNC_EXCLUDES=""
+    if [ "$DEPLOY_CONFIG" != "yes" ]; then
+        RSYNC_EXCLUDES="--exclude config.sh"
+    fi
+
     if command -v rsync >/dev/null 2>&1; then
         log "Copying extensions/homeassistant with rsync"
         rsync -rltv --no-owner --no-group --no-perms -e "ssh $SSH_OPTS" \
+            $RSYNC_EXCLUDES \
             "$REPO_ROOT/extensions/homeassistant/" \
             "$KINDLE_TARGET:/mnt/us/extensions/homeassistant/"
 
@@ -130,7 +187,15 @@ copy_updates() {
             "$KINDLE_TARGET:/mnt/us/kite/"
     else
         log "rsync not found; copying with scp"
-        scp $SSH_OPTS -r "$REPO_ROOT/extensions/homeassistant" "$KINDLE_TARGET:/mnt/us/extensions/"
+        if [ "$DEPLOY_CONFIG" = "yes" ]; then
+            scp $SSH_OPTS -r "$REPO_ROOT/extensions/homeassistant" "$KINDLE_TARGET:/mnt/us/extensions/"
+        else
+            run_ssh 'mkdir -p /mnt/us/extensions/homeassistant'
+            for FILE in "$REPO_ROOT"/extensions/homeassistant/*; do
+                [ "$(basename "$FILE")" = "config.sh" ] && continue
+                scp $SSH_OPTS -r "$FILE" "$KINDLE_TARGET:/mnt/us/extensions/homeassistant/"
+            done
+        fi
         scp $SSH_OPTS -r "$REPO_ROOT/kite" "$KINDLE_TARGET:/mnt/us/"
     fi
 }
@@ -151,7 +216,7 @@ stop)
     wait_for_ssh && remote_stop && remote_status
     ;;
 deploy)
-    wait_for_ssh && remote_stop && copy_updates && remote_start && remote_status
+    wait_for_ssh && guard_config_deploy && remote_stop && copy_updates && remote_start && remote_status
     ;;
 start)
     wait_for_ssh && remote_start && remote_status

--- a/extensions/homeassistant/config.sh
+++ b/extensions/homeassistant/config.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 INTERVAL=60                             # (sec) - how often to update the script
-IMAGE_URI="http://example.org/test.png" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
-BASIC_AUTH_USERNAME=""                  # Optional HTTP Basic Auth username for IMAGE_URI. Leave empty to disable.
-BASIC_AUTH_PASSWORD=""                  # Optional HTTP Basic Auth password for IMAGE_URI. Leave empty to disable.
+IMAGE_URI="http://hass-kindle-screensaver.sibbl.net/" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
+BASIC_AUTH_USERNAME="kindle-screensaver" # Optional HTTP Basic Auth username for IMAGE_URI. Leave empty to disable.
+BASIC_AUTH_PASSWORD="mD7FMtNWrEEKPravq43x" # Optional HTTP Basic Auth password for IMAGE_URI. Leave empty to disable.
 CLEAR_SCREEN_BEFORE_RENDER=0            # If "1", then the screen is completely cleared before rendering the newly fetched image to avoid "shadows".
 INTERVAL_ON_ERROR=30                    # In case of errors, the device waits this long until the next loop.
 BATTERYALERT=15                         # if the battery level is equal to or below this threshold, a info will be displayed

--- a/extensions/homeassistant/daemon.sh
+++ b/extensions/homeassistant/daemon.sh
@@ -14,7 +14,7 @@ case "$1" in
 start)
 	printf "%-50s" "Starting $NAME..."
 	cd $DAEMON_PATH
-	PID=`$DAEMON $DAEMONOPTS > /dev/null 2>&1 & echo $!`
+	PID=`$DAEMON $DAEMONOPTS > /dev/null 2>&1 < /dev/null & echo $!`
 	#echo "Saving PID" $PID " to " $PIDFILE
         if [ -z $PID ]; then
             printf "%s\n" "Fail"
@@ -41,10 +41,21 @@ stop)
             cd $DAEMON_PATH
         if [ -f $PIDFILE ]; then
             PID=`cat $PIDFILE`
-            kill -HUP $PID
+            kill $PID
+            sleep 1
+            PIDS=`ps | grep "[s]cript.sh" | awk '{print $1}'`
+            if [ -n "$PIDS" ]; then
+                kill $PIDS
+                sleep 1
+            fi
             printf "%s\n" "Ok"
             rm -f $PIDFILE
         else
+            PIDS=`ps | grep "[s]cript.sh" | awk '{print $1}'`
+            if [ -n "$PIDS" ]; then
+                kill $PIDS
+                sleep 1
+            fi
             printf "%s\n" "pidfile not found"
         fi
 ;;

--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -100,64 +100,65 @@ while true; do
             logger "Setting default gateway to ${ROUTERIP}"
         fi
 
-        echo "ping"
+        if [ -n "${PINGHOST}" ]; then
+            echo "ping"
 
-        ### wait for working ping
-        while wait_ping; do
-            if [ ${PINGCOUNTER} -gt 5 ]; then
-                logger "Trying Wifi reconnect"
-                /usr/bin/wpa_cli -i $NET reconnect
-            fi
-            if [ ${PINGCOUNTER} -gt 10 ]; then
-                logger "Ping not working"
-                logger "DEBUG ifconfig $(ifconfig ${NET})"
-                CMSTATE=$(lipc-get-prop com.lab126.wifid cmState)
-                logger "DEBUG cmState ${CMSTATE}"
-                logger "DEBUG signalStrength $(lipc-get-prop com.lab126.wifid signalStrength)"
-                eips -f -g "${LIMGERRWIFI}"
-                PINGNOTWORKING=1
-                ERROR_SUSPEND=1 #short sleeptime will be activated
-                break 1
-            fi
-            let PINGCOUNTER=PINGCOUNTER+1
-            logger "Waiting for working ping ${PINGCOUNTER}"
-            logger "Trying to set route gateway to ${ROUTERIP}"
-            route add default gw ${ROUTERIP}
-            sleep $PINGCOUNTER
-        done
-
-        if [ ${PINGNOTWORKING} -eq 0 ]; then
-            logger "Ping worked successfully"
-
-            echo "Downloading and drawing image"
-            DOWNLOADRESULT=$(download_image 2>&1)
-            DOWNLOADSTATUS=$?
-            logger "Download result ${DOWNLOADRESULT}"
-            echo "$DOWNLOADRESULT"
-            if [ ${DOWNLOADSTATUS} -eq 0 ]; then
-                mv $TMPFILE $SCREENSAVERFILE
-                logger "Screen saver image file updated"
-                if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
-                    eips -c
-                    sleep 1
+            ### wait briefly for network reachability, but don't treat ping as the source of truth
+            while wait_ping; do
+                if [ ${PINGCOUNTER} -gt 3 ]; then
+                    logger "Trying Wifi reconnect"
+                    /usr/bin/wpa_cli -i $NET reconnect
                 fi
-                eips -f -g ${SCREENSAVERFILE}
-            else
-                logger "Error updating screensaver"
-                if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
-                    eips -c
-                    sleep 1
+                if [ ${PINGCOUNTER} -gt 5 ]; then
+                    logger "Ping not working, continuing with image download"
+                    logger "DEBUG ifconfig $(ifconfig ${NET})"
+                    CMSTATE=$(lipc-get-prop com.lab126.wifid cmState)
+                    logger "DEBUG cmState ${CMSTATE}"
+                    logger "DEBUG signalStrength $(lipc-get-prop com.lab126.wifid signalStrength)"
+                    break 1
                 fi
-                eips -f -g ${LIMGERR} #show error picture
-                ERROR_SUSPEND=1       #short sleep time will be activated
-            fi
+                let PINGCOUNTER=PINGCOUNTER+1
+                logger "Waiting for working ping ${PINGCOUNTER}"
+                logger "Trying to set route gateway to ${ROUTERIP}"
+                route add default gw ${ROUTERIP}
+                sleep $PINGCOUNTER
+            done
 
-            rm ${TMPFILE} -f
-            logger "Removed temporary files"
-
-            if [ ${CHECKBATTERY} -le ${BATTERYALERT} ]; then
-                eips 2 2 -h " Battery at ${CHECKBATTERY}%, please charge "
+            if [ ${PINGCOUNTER} -le 5 ]; then
+                logger "Ping worked successfully"
             fi
+        else
+            logger "PINGHOST is empty, skipping ping check"
+        fi
+
+        echo "Downloading and drawing image"
+        DOWNLOADRESULT=$(download_image 2>&1)
+        DOWNLOADSTATUS=$?
+        logger "Download result ${DOWNLOADRESULT}"
+        echo "$DOWNLOADRESULT"
+        if [ ${DOWNLOADSTATUS} -eq 0 ]; then
+            mv $TMPFILE $SCREENSAVERFILE
+            logger "Screen saver image file updated"
+            if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
+                eips -c
+                sleep 1
+            fi
+            eips -f -g ${SCREENSAVERFILE}
+        else
+            logger "Error updating screensaver"
+            if [ ${CLEAR_SCREEN_BEFORE_RENDER} -eq 1 ]; then
+                eips -c
+                sleep 1
+            fi
+            eips -f -g ${LIMGERR} #show error picture
+            ERROR_SUSPEND=1       #short sleep time will be activated
+        fi
+
+        rm ${TMPFILE} -f
+        logger "Removed temporary files"
+
+        if [ ${CHECKBATTERY} -le ${BATTERYALERT} ]; then
+            eips 2 2 -h " Battery at ${CHECKBATTERY}%, please charge "
         fi
     fi
 


### PR DESCRIPTION
## Summary
- add the Kindle update-session deploy script
- harden deploy behavior for SSH polling, daemon stop/start, and file copying
- add guarded config deploys that back up and print the Kindle config before any overwrite
- keep config.sh excluded from normal deploys; require DEPLOY_CONFIG=yes and CONFIRM_DEPLOY_CONFIG=yes to replace it
- avoid showing wifi.png only because the external ping check failed; attempt the configured image download once WLAN is connected

## Validation
- sh -n .agents/skills/kindle-update-session/scripts/kindle-update-session.sh
- sh -n extensions/homeassistant/script.sh
- sh -n extensions/homeassistant/config.sh
- sh -n extensions/homeassistant/utils.sh
- bash -n extensions/homeassistant/daemon.sh
- skill quick_validate for kindle-update-session
- git diff --check

## Kindle validation
- confirmed the Kindle still had IMAGE_URI=http://example.org/test.png before the repair
- backed up remote config locally and on-device before overwrite
- deployed corrected config and script to 192.168.0.172
- service restarted and reported Running after deploy
