### PR TITLE
Use authorization header for basic auth downloads

### DIFF
--- a/extensions/homeassistant/config.sh
+++ b/extensions/homeassistant/config.sh
@@ -4,6 +4,7 @@ INTERVAL=60                             # (sec) - how often to update the script
 IMAGE_URI="http://hass-kindle-screensaver.sibbl.net/" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
 BASIC_AUTH_USERNAME="kindle-screensaver" # Optional HTTP Basic Auth username for IMAGE_URI. Leave empty to disable.
 BASIC_AUTH_PASSWORD="mD7FMtNWrEEKPravq43x" # Optional HTTP Basic Auth password for IMAGE_URI. Leave empty to disable.
+BASIC_AUTH_HEADER="a2luZGxlLXNjcmVlbnNhdmVyOm1EN0ZNdE5XckVFS1ByYXZxNDN4" # Optional precomputed base64 "username:password" token for older Kindles.
 CLEAR_SCREEN_BEFORE_RENDER=0            # If "1", then the screen is completely cleared before rendering the newly fetched image to avoid "shadows".
 INTERVAL_ON_ERROR=30                    # In case of errors, the device waits this long until the next loop.
 BATTERYALERT=15                         # if the battery level is equal to or below this threshold, a info will be displayed

--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -29,6 +29,17 @@ download_image() {
     DOWNLOAD_URI=$IMAGE_URI
 
     if [ -n "$BASIC_AUTH_USERNAME" ] || [ -n "$BASIC_AUTH_PASSWORD" ]; then
+        if [ -n "${BASIC_AUTH_HEADER:-}" ] && wget --help 2>&1 | grep -q -- '--header'; then
+            wget -q --header "Authorization: Basic ${BASIC_AUTH_HEADER}" "$IMAGE_URI" -O "$TMPFILE"
+            return $?
+        fi
+
+        if command -v base64 >/dev/null 2>&1 && wget --help 2>&1 | grep -q -- '--header'; then
+            BASIC_AUTH_TOKEN=$(printf '%s:%s' "$BASIC_AUTH_USERNAME" "$BASIC_AUTH_PASSWORD" | base64 | tr -d '\n')
+            wget -q --header "Authorization: Basic ${BASIC_AUTH_TOKEN}" "$IMAGE_URI" -O "$TMPFILE"
+            return $?
+        fi
+
         case "$IMAGE_URI" in
         http://*)
             DOWNLOAD_URI="http://${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}@${IMAGE_URI#http://}"


### PR DESCRIPTION
## Summary
- add an optional precomputed Basic Auth token to config.sh for older Kindle environments
- prefer wget Authorization headers for authenticated image downloads
- keep the existing user:password URL fallback when header support is unavailable

## Validation
- sh -n extensions/homeassistant/config.sh
- sh -n extensions/homeassistant/utils.sh
- sh -n extensions/homeassistant/script.sh
- bash -n extensions/homeassistant/daemon.sh
- sh -n .agents/skills/kindle-update-session/scripts/kindle-update-session.sh
- skill quick_validate for kindle-update-session
- git diff --check

## Live status
- server returns 401 without auth and 200 PNG with the Authorization header