### PR TITLE
Use user/password basic auth only

### DIFF
--- a/extensions/homeassistant/config.sh
+++ b/extensions/homeassistant/config.sh
@@ -2,9 +2,8 @@
 
 INTERVAL=60                             # (sec) - how often to update the script
 IMAGE_URI="http://hass-kindle-screensaver.sibbl.net/" # URL of image to fetch. Keep in mind that the Kindle 4 does not support SSL/TLS requests
-BASIC_AUTH_USERNAME="kindle-screensaver" # Optional HTTP Basic Auth username for IMAGE_URI. Leave empty to disable.
-BASIC_AUTH_PASSWORD="mD7FMtNWrEEKPravq43x" # Optional HTTP Basic Auth password for IMAGE_URI. Leave empty to disable.
-BASIC_AUTH_HEADER="a2luZGxlLXNjcmVlbnNhdmVyOm1EN0ZNdE5XckVFS1ByYXZxNDN4" # Optional precomputed base64 "username:password" token for older Kindles.
+BASIC_AUTH_USERNAME=""                  # Optional HTTP Basic Auth username for IMAGE_URI. Leave empty to disable.
+BASIC_AUTH_PASSWORD=""                  # Optional HTTP Basic Auth password for IMAGE_URI. Leave empty to disable.
 CLEAR_SCREEN_BEFORE_RENDER=0            # If "1", then the screen is completely cleared before rendering the newly fetched image to avoid "shadows".
 INTERVAL_ON_ERROR=30                    # In case of errors, the device waits this long until the next loop.
 BATTERYALERT=15                         # if the battery level is equal to or below this threshold, a info will be displayed

--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+PATH="/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+export PATH
 
 # load config
 if [ -e "config.sh" ]; then

--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -11,7 +11,7 @@ kill_kindle() {
 }
 
 customize_kindle() {
-    mkdir /mnt/us/update.bin.tmp.partial -f # prevent from Amazon updates
+    mkdir -p /mnt/us/update.bin.tmp.partial # prevent from Amazon updates
     touch /mnt/us/WIFI_NO_NET_PROBE         # do not perform a WLAN test
 }
 
@@ -29,17 +29,6 @@ download_image() {
     DOWNLOAD_URI=$IMAGE_URI
 
     if [ -n "$BASIC_AUTH_USERNAME" ] || [ -n "$BASIC_AUTH_PASSWORD" ]; then
-        if [ -n "${BASIC_AUTH_HEADER:-}" ] && wget --help 2>&1 | grep -q -- '--header'; then
-            wget -q --header "Authorization: Basic ${BASIC_AUTH_HEADER}" "$IMAGE_URI" -O "$TMPFILE"
-            return $?
-        fi
-
-        if command -v base64 >/dev/null 2>&1 && wget --help 2>&1 | grep -q -- '--header'; then
-            BASIC_AUTH_TOKEN=$(printf '%s:%s' "$BASIC_AUTH_USERNAME" "$BASIC_AUTH_PASSWORD" | base64 | tr -d '\n')
-            wget -q --header "Authorization: Basic ${BASIC_AUTH_TOKEN}" "$IMAGE_URI" -O "$TMPFILE"
-            return $?
-        fi
-
         case "$IMAGE_URI" in
         http://*)
             DOWNLOAD_URI="http://${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}@${IMAGE_URI#http://}"


### PR DESCRIPTION
## Summary
- keep Basic Auth to the Kindle-tested user/password URL form only
- remove the header/Base64 auth path entirely
- reset repository auth defaults to empty values so secrets stay device-local
- add PATH setup for Kindle command lookup during manual/debug runs
- fix Kindle BusyBox mkdir usage

## Validation
- sh -n extensions/homeassistant/config.sh
- sh -n extensions/homeassistant/utils.sh
- sh -n extensions/homeassistant/script.sh
- git diff origin/main..HEAD --check
- searched tracked working tree paths for leaked password fragments, Base64/header auth, conflict markers, and example token text

## Kindle validation
- daemon was disabled before debugging
- script.sh was run manually with RTC sleep disabled
- manual run downloaded and updated cover.png successfully using user/password auth
- USE_RTC was restored and daemon was restarted with one script.sh process
