### PR TITLE
Harden ping and download handling

### DIFF
--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -107,10 +107,6 @@ while true; do
 
             ### wait briefly for network reachability, but don't treat ping as the source of truth
             while wait_ping; do
-                if [ ${PINGCOUNTER} -gt 3 ]; then
-                    logger "Trying Wifi reconnect"
-                    /usr/bin/wpa_cli -i $NET reconnect
-                fi
                 if [ ${PINGCOUNTER} -gt 5 ]; then
                     logger "Ping not working, continuing with image download"
                     logger "DEBUG ifconfig $(ifconfig ${NET})"

--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -27,6 +27,7 @@ wait_ping() {
 
 download_image() {
     DOWNLOAD_URI=$IMAGE_URI
+    rm "$TMPFILE" -f
 
     if [ -n "$BASIC_AUTH_USERNAME" ] || [ -n "$BASIC_AUTH_PASSWORD" ]; then
         case "$IMAGE_URI" in


### PR DESCRIPTION
## Summary
- stop reconnecting Wi-Fi just because the optional ping check failed
- keep the image download as the source of truth after Wi-Fi is connected
- remove stale temp image files before wget so BusyBox wget does not fail with File exists

## Validation
- sh -n extensions/homeassistant/script.sh
- sh -n extensions/homeassistant/utils.sh
- git diff --cached --check before commit
- confirmed staged changes touched only script.sh and utils.sh, not config.sh

## Kindle validation
- tested with PINGHOST=8.8.8.8 on the device
- manual run succeeded: ping worked, download succeeded, cover.png updated, Wi-Fi remained CONNECTED
