### PR TITLE
Add watchdog around ping checks

### DIFF
--- a/extensions/homeassistant/utils.sh
+++ b/extensions/homeassistant/utils.sh
@@ -21,7 +21,21 @@ wait_wlan() {
 
 wait_ping() {
     CONNECTED=0
-    /bin/ping -c 1 $PINGHOST >/dev/null && CONNECTED=1
+    PING_TIMEOUT_SECONDS=${PING_TIMEOUT:-10}
+    /bin/ping -c 1 "$PINGHOST" >/dev/null 2>&1 &
+    PING_PID=$!
+    (
+        sleep "$PING_TIMEOUT_SECONDS"
+        kill "$PING_PID" >/dev/null 2>&1
+    ) &
+    PING_WATCHDOG_PID=$!
+
+    wait "$PING_PID"
+    PING_STATUS=$?
+    kill "$PING_WATCHDOG_PID" >/dev/null 2>&1
+    wait "$PING_WATCHDOG_PID" 2>/dev/null
+
+    [ "$PING_STATUS" -eq 0 ] && CONNECTED=1
     return $CONNECTED
 }
 


### PR DESCRIPTION
## Summary
- wrap Kindle ping checks in a shell watchdog so BusyBox ping cannot hang forever
- keep the existing success/failure return behavior for the caller

## Validation
- sh -n extensions/homeassistant/config.sh
- sh -n extensions/homeassistant/utils.sh
- sh -n extensions/homeassistant/script.sh
- sh -n extensions/homeassistant/startup.sh
- sh -n kite/onboot/homeassistant.sh
- bash -n extensions/homeassistant/daemon.sh
- git diff --check
- deployed utils.sh to the Kindle and verified the dashboard updated again after the stalled ping state