### PR TITLE
Limit Wi-Fi reconnect wait loop

### DIFF
--- a/extensions/homeassistant/script.sh
+++ b/extensions/homeassistant/script.sh
@@ -71,11 +71,11 @@ while true; do
 
     ### wait for wifi
     while wait_wlan; do
-        if [ ${WLANCOUNTER} -gt 5 ]; then
+        if [ ${WLANCOUNTER} -eq 5 ]; then
             logger "Trying Wifi reconnect"
             /usr/bin/wpa_cli -i $NET reconnect
         fi
-        if [ ${WLANCOUNTER} -gt 30 ]; then
+        if [ ${WLANCOUNTER} -gt 15 ]; then
             logger "No known wifi found"
             logger "DEBUG ifconfig $(ifconfig ${NET})"
             logger "DEBUG cmState $(lipc-get-prop com.lab126.wifid cmState)"
@@ -87,7 +87,7 @@ while true; do
         fi
         let WLANCOUNTER=WLANCOUNTER+1
         logger "Waiting for wifi ${WLANCOUNTER}"
-        sleep $WLANCOUNTER
+        sleep 2
     done
 
     if [ ${WLANNOTCONNECTED} -eq 0 ]; then


### PR DESCRIPTION
## Summary
- issue one explicit Wi-Fi reconnect attempt per update loop instead of repeatedly disrupting wifid
- cap the Wi-Fi association wait at roughly 32 seconds
- use fixed short waits so prolonged outages cannot keep the Kindle awake for minutes per retry

The next error cycle still retries Wi-Fi automatically, so the Kindle reconnects after an extended outage while spending most of the outage suspended.

## Validation
- sh -n extensions/homeassistant/config.sh
- sh -n extensions/homeassistant/utils.sh
- sh -n extensions/homeassistant/script.sh
- sh -n extensions/homeassistant/startup.sh
- sh -n kite/onboot/homeassistant.sh
- bash -n extensions/homeassistant/daemon.sh
- git diff --check
- deployed to the Kindle and verified successful update, suspend/wake cycle, and increasing battery charge